### PR TITLE
Major version bump and add setOptions for setOperation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firestore-batcher",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "firestore-batcher",
-      "version": "0.4.1",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "firebase-admin": "^11.2.1",
@@ -14,7 +14,7 @@
         "typescript": "^4.0.5"
       },
       "peerDependencies": {
-        "firebase-admin": ">= 10"
+        "firebase-admin": ">=11"
       }
     },
     "node_modules/@babel/parser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-batcher",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "description": "Batching Firestore operations without the hassle",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/entur/firebase-batcher.git"
+    "url": "git+https://github.com/entur/firestore-batcher.git"
   },
   "keywords": [
     "firebase",
@@ -27,9 +27,9 @@
   "author": "Entur AS",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/entur/firebase-batcher/issues"
+    "url": "https://github.com/entur/firestore-batcher/issues"
   },
-  "homepage": "https://github.com/entur/firebase-batcher#readme",
+  "homepage": "https://github.com/entur/firestore-batcher#readme",
   "devDependencies": {
     "firebase-admin": "^11.2.1",
     "prettier": "^2.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
     UpdateData,
     WithFieldValue,
     WriteBatch,
+    SetOptions,
 } from 'firebase-admin/firestore'
 
 enum OperationName {
@@ -51,16 +52,19 @@ interface SetOperation<T> {
     name: OperationName.SET
     documentRef: DocumentReference<T>
     data: WithFieldValue<T>
+    setOptions: SetOptions
 }
 
 export function setOperation<T>(
     documentRef: DocumentReference<T>,
     data: WithFieldValue<T>,
+    setOptions: SetOptions = {},
 ): SetOperation<T> {
     return {
         name: OperationName.SET,
         documentRef,
         data,
+        setOptions,
     }
 }
 
@@ -123,7 +127,7 @@ function addOperationToBatch<T>(
             batch.delete(documentRef, operation.precondition)
             break
         case OperationName.SET:
-            batch.set(documentRef, operation.data)
+            batch.set(documentRef, operation.data, operation.setOptions)
             break
         case OperationName.UPDATE: {
             if (operation.precondition) {


### PR DESCRIPTION
- Do a major bump due to breaking change of firebase-admin dependency requirement of >=11
- Add the ability to use [setOptions](https://googleapis.dev/nodejs/firestore/latest/global.html#SetOptions) to set `merge` or `mergeFields` during `setOperation`
- Fix url to point to the correct repo